### PR TITLE
Move LpwdTest.java to proper test directory structure

### DIFF
--- a/src/test/java/sftpClientTests/IntentTests/LpwdTest.java
+++ b/src/test/java/sftpClientTests/IntentTests/LpwdTest.java
@@ -1,4 +1,4 @@
-package sftpClient;
+package test.java.sftpClientTests.IntentTests;
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
- Move from src/sftpClient/LpwdTest.java to src/test/java/sftpClientTests/IntentTests/LpwdTest.java
- Update package declaration to test.java.sftpClientTests.IntentTests
- Follows project's standard test directory structure